### PR TITLE
Changed SDK script src

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <title>Cisco Webex Embedded Apps Framework Testing Harness</title>
-  <script src="https://binaries.webex.com/static-content-pipeline/webex-embedded-app/v1/webex-embedded-app-sdk.js" defer></script>
+  <script src="https://binaries.webex.com/preview-webex-jssdk/webex-embedded-app-sdk-master.js" defer></script>
   <script src="./index.js" defer></script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">


### PR DESCRIPTION
This PR updates the <script> tag's src attribute to point to the SDK that David is using for his sample app.

<img width="927" alt="image" src="https://user-images.githubusercontent.com/408952/128781875-e2d02efa-2b73-4fdf-95c9-c349d188b9a6.png">
